### PR TITLE
text_input: ability to move caret

### DIFF
--- a/libopensesame/widgets/_text_input.py
+++ b/libopensesame/widgets/_text_input.py
@@ -101,7 +101,7 @@ class text_input(label):
 		self.var = var
 		self.text = self.form.experiment.unistr(text)
 		self.set_var(text)
-		self.caretPos = None 	# set at end of text in box on each focus
+		self.caret_pos = None
 		
 	def render(self):
 	
@@ -118,7 +118,8 @@ class text_input(label):
 		if self.text == '' and not self.focus:
 			self.draw_text(self.stub, html=False)	
 		elif self.focus:
-			self.draw_text(self.text[:self.caretPos] + self.prompt + self.text[self.caretPos:], html=False)	
+			self.draw_text(self.text[:self.caret_pos] + self.prompt + 
+							self.text[self.caret_pos:], html=False)	
 		else:
 			self.draw_text(self.text, html=False)	
 				
@@ -136,7 +137,7 @@ class text_input(label):
 		"""
 		
 		self.focus = True
-		self.caretPos = len(self.text)
+		self.caret_pos = len(self.text)
 		my_keyboard = keyboard(self.form.experiment)
 		my_keyboard.show_virtual_keyboard(True)
 		while True:		
@@ -147,13 +148,16 @@ class text_input(label):
 			except:
 				o = None
 			if resp == u'space':			
-				self.text = self.text[:self.caretPos] + ' ' + self.text[self.caretPos:]
-				self.caretPos +=1
+				self.text = self.text[:self.caret_pos] + ' ' +\
+							self.text[self.caret_pos:]
+				self.caret_pos +=1
 			elif resp == u'backspace' or o == 8:
-				self.text = self.text[:self.caretPos-1] + self.text[self.caretPos:]
-				self.caretPos = max(0,self.caretPos-1)
+				self.text = self.text[:self.caret_pos-1] +\
+							self.text[self.caret_pos:]
+				self.caret_pos = max(0,self.caret_pos-1)
 			elif resp == u'delete':
-				self.text = self.text[:self.caretPos] + self.text[self.caretPos+1:]
+				self.text = self.text[:self.caret_pos] +\
+							self.text[self.caret_pos+1:]
 			elif resp == u'tab':
 				self.focus = False
 				my_keyboard.show_virtual_keyboard(False)
@@ -166,13 +170,13 @@ class text_input(label):
 					self.focus = False
 					my_keyboard.show_virtual_keyboard(False)
 					return None
-			# move caret
 			elif resp == u'left':
-				self.caretPos = max(0,self.caretPos-1)
+				self.caret_pos = max(0,self.caret_pos-1)
 			elif resp == u'right':
-				self.caretPos = min(len(self.text),self.caretPos+1)
+				self.caret_pos = min(len(self.text),self.caret_pos+1)
 			elif len(resp) == 1:
-				self.text = self.text[:self.caretPos] + resp + self.text[self.caretPos:]
-				self.caretPos +=1
+				self.text = self.text[:self.caret_pos] + resp +\
+							self.text[self.caret_pos:]
+				self.caret_pos +=1
 			self.set_var(self.text)
 

--- a/libopensesame/widgets/_text_input.py
+++ b/libopensesame/widgets/_text_input.py
@@ -101,6 +101,7 @@ class text_input(label):
 		self.var = var
 		self.text = self.form.experiment.unistr(text)
 		self.set_var(text)
+		self.caretPos = None 	# set at end of text in box on each focus
 		
 	def render(self):
 	
@@ -117,7 +118,7 @@ class text_input(label):
 		if self.text == '' and not self.focus:
 			self.draw_text(self.stub, html=False)	
 		elif self.focus:
-			self.draw_text(self.text+self.prompt, html=False)	
+			self.draw_text(self.text[:self.caretPos] + self.prompt + self.text[self.caretPos:], html=False)	
 		else:
 			self.draw_text(self.text, html=False)	
 				
@@ -135,6 +136,7 @@ class text_input(label):
 		"""
 		
 		self.focus = True
+		self.caretPos = len(self.text)
 		my_keyboard = keyboard(self.form.experiment)
 		my_keyboard.show_virtual_keyboard(True)
 		while True:		
@@ -145,9 +147,11 @@ class text_input(label):
 			except:
 				o = None
 			if resp == u'space':			
-				self.text += ' '
+				self.text = self.text[:self.caretPos] + ' ' + self.text[self.caretPos:]
+				self.caretPos +=1
 			elif resp == u'backspace' or o == 8:
-				self.text = self.text[:-1]
+				self.text = self.text[:self.caretPos-1] + self.text[self.caretPos:]
+				self.caretPos = max(0,self.caretPos-1)
 			elif resp == u'tab':
 				self.focus = False
 				my_keyboard.show_virtual_keyboard(False)
@@ -160,7 +164,13 @@ class text_input(label):
 					self.focus = False
 					my_keyboard.show_virtual_keyboard(False)
 					return None
+			# move caret
+			elif resp == u'left':
+				self.caretPos = max(0,self.caretPos-1)
+			elif resp == u'right':
+				self.caretPos = min(len(self.text),self.caretPos+1)
 			elif len(resp) == 1:
-				self.text += resp
+				self.text = self.text[:self.caretPos] + resp + self.text[self.caretPos:]
+				self.caretPos +=1
 			self.set_var(self.text)
 

--- a/libopensesame/widgets/_text_input.py
+++ b/libopensesame/widgets/_text_input.py
@@ -152,6 +152,8 @@ class text_input(label):
 			elif resp == u'backspace' or o == 8:
 				self.text = self.text[:self.caretPos-1] + self.text[self.caretPos:]
 				self.caretPos = max(0,self.caretPos-1)
+			elif resp == u'delete':
+				self.text = self.text[:self.caretPos] + self.text[self.caretPos+1:]
 			elif resp == u'tab':
 				self.focus = False
 				my_keyboard.show_virtual_keyboard(False)


### PR DESCRIPTION
Needed to be able to move caret around in inputted text. Can now process leftward and rightward arrow key to move in inputted string. Also added processing of delete key as caret can now be in middle of string. Very 1980s feel i know (even the Windows terminal has a less nerdy caret), but hey!