### PR TITLE
Changing method how to draw an arrow 

### DIFF
--- a/libopensesame/sketchpad_elements/_arrow.py
+++ b/libopensesame/sketchpad_elements/_arrow.py
@@ -19,8 +19,6 @@ along with openexp.  If not, see <http://www.gnu.org/licenses/>.
 
 from libopensesame.sketchpad_elements._base_element import base_element
 
-
-
 class arrow(base_element):
 
 	"""
@@ -40,15 +38,16 @@ class arrow(base_element):
 		"""
 
 		defaults = [
-			(u'x1'			, None),
-			(u'y1'			, None),
-			(u'x2'			, None),
-			(u'y2'			, None),
-			(u'proportion'	, 0.8),
-			(u'arrow_width'	, 30),
-			(u'color'		, sketchpad.get(u'foreground')),
-			(u'penwidth'	, 1),
-			(u'fill'		, True),
+			(u'x1'				, None),
+			(u'y1'				, None),
+			(u'x2'				, None),
+			(u'y2'				, None),
+			(u'proportion'		, 0.8),
+			(u'arrow_width'		, 30),
+			(u'arrowhead_width'	, 0.5),
+			(u'color'			, sketchpad.get(u'foreground')),
+			(u'penwidth'		, 1),
+			(u'fill'			, True),
 			]
 		super(arrow, self).__init__(sketchpad, string, defaults=defaults)
 
@@ -64,6 +63,7 @@ class arrow(base_element):
 			properties[u'x2'], properties[u'y2'],
 			color=properties[u'color'],
 			penwidth=properties[u'penwidth'],
+			arrowhead_width=properties[u'arrowhead_width'],
 			proportion=properties[u'proportion'],
 			arrow_width=properties[u'arrow_width'],
 			fill=properties[u'fill'])

--- a/libopensesame/sketchpad_elements/_arrow.py
+++ b/libopensesame/sketchpad_elements/_arrow.py
@@ -19,6 +19,8 @@ along with openexp.  If not, see <http://www.gnu.org/licenses/>.
 
 from libopensesame.sketchpad_elements._base_element import base_element
 
+
+
 class arrow(base_element):
 
 	"""
@@ -42,9 +44,11 @@ class arrow(base_element):
 			(u'y1'			, None),
 			(u'x2'			, None),
 			(u'y2'			, None),
-			(u'arrow_size'	, 20),
+			(u'proportion'	, 0.8),
+			(u'arrow_width'	, 30),
 			(u'color'		, sketchpad.get(u'foreground')),
 			(u'penwidth'	, 1),
+			(u'fill'		, True),
 			]
 		super(arrow, self).__init__(sketchpad, string, defaults=defaults)
 
@@ -60,5 +64,7 @@ class arrow(base_element):
 			properties[u'x2'], properties[u'y2'],
 			color=properties[u'color'],
 			penwidth=properties[u'penwidth'],
-			arrow_size=properties[u'arrow_size'])
+			proportion=properties[u'proportion'],
+			arrow_width=properties[u'arrow_width'],
+			fill=properties[u'fill'])
 

--- a/libqtopensesame/items/feedpad.py
+++ b/libqtopensesame/items/feedpad.py
@@ -249,6 +249,14 @@ class feedpad(QtCore.QObject):
 	@property
 	def current_arrow_size(self):
 		return self.sketchpad_widget.current_arrow_size
+	
+	@property
+	def current_arrow_width(self):
+		return self.sketchpad_widget.current_arrow_width
+	
+	@property
+	def current_proportion(self):
+		return self.sketchpad_widget.current_proportion
 
 	@property
 	def current_scale(self):

--- a/libqtopensesame/items/feedpad.py
+++ b/libqtopensesame/items/feedpad.py
@@ -253,6 +253,10 @@ class feedpad(QtCore.QObject):
 	@property
 	def current_arrow_width(self):
 		return self.sketchpad_widget.current_arrow_width
+
+	@property
+	def current_arrowhead_width(self):
+		return self.sketchpad_widget.current_arrowhead_width
 	
 	@property
 	def current_proportion(self):

--- a/libqtopensesame/misc/sketchpad_canvas.py
+++ b/libqtopensesame/misc/sketchpad_canvas.py
@@ -644,34 +644,32 @@ class sketchpad_canvas(QtGui.QGraphicsScene):
 		# direction  
 		angle = math.atan2(ey-sy,ex-sx)
 
+	def arrow(self, sx, sy, ex, ey, proportion=0.7, arrow_width=30, 
+		arrowhead_width=0.5, color=None, fill=False, penwidth=None, add=True):
 
+		"""Mimicks canvas api. See openexp._canvas.canvas."""
 
-
-	def arrow(self,sx,sy,ex,ey,proportion = 0.7, arrow_width = 30,color = None, 
-		fill= False, penwidth = None, add = True):
 		# length
 		d = math.sqrt((ey-sy)**2 + (sx-ex)**2)
 		# direction  
 		angle = math.atan2(ey-sy,ex-sx)
-		
+		head_width = arrowhead_width/2.0 
+		body_width = (1-arrowhead_width)/2.0 
+		# calculate coordinates
 		p0 = (sx,sy)
 		p4 = (ex,ey)
-
-		p1 = (sx + 0.25 * arrow_width * math.cos(angle - math.pi/2),\
-			sy + 0.25 * arrow_width * math.sin(angle - math.pi/2))
-
+		p1 = (sx +body_width * arrow_width * math.cos(angle - math.pi/2),\
+			sy + body_width * arrow_width * math.sin(angle - math.pi/2))
 		p2 = (p1[0] + proportion*math.cos(angle) * d, \
 		 	p1[1] + proportion * math.sin(angle) * d)
-		p3 = (p2[0] + 0.25 * arrow_width * math.cos(angle - math.pi/2), \
-			p2[1] + 0.25 * arrow_width * math.sin(angle - math.pi/2))
-		
-		p7 = (sx + 0.25 * arrow_width*math.cos(angle + math.pi/2), \
-			sy + 0.25 * arrow_width*math.sin(angle + math.pi/2))
+		p3 = (p2[0]+head_width * arrow_width * math.cos(angle-math.pi/2),\
+			p2[1] + head_width * arrow_width * math.sin(angle-math.pi/2))
+		p7 = (sx + body_width * arrow_width*math.cos(angle + math.pi/2),\
+			sy + body_width * arrow_width*math.sin(angle + math.pi/2))
 		p6 = (p7[0] + proportion * math.cos(angle) * d, \
 		 	p7[1] + proportion * math.sin(angle) * d)
-		p5 = (p6[0] + 0.25 * arrow_width * math.cos(angle + math.pi/2), \
-			p6[1] + 0.25 * arrow_width * math.sin(angle + math.pi/2))
-
+		p5 = (p6[0]+head_width * arrow_width * math.cos(angle+math.pi/2),\
+			p6[1]+head_width * arrow_width * math.sin(angle+math.pi/2))
 		color = self._color(color)
 		if fill:
 			pen = self._pen(color, 1)

--- a/libqtopensesame/misc/sketchpad_canvas.py
+++ b/libqtopensesame/misc/sketchpad_canvas.py
@@ -640,29 +640,55 @@ class sketchpad_canvas(QtGui.QGraphicsScene):
 		if add:
 			self.addItem(i)
 		return i
+		d = math.sqrt((ey-sy)**2 + (sx-ex)**2)
+		# direction  
+		angle = math.atan2(ey-sy,ex-sx)
 
-	def arrow(self, sx, sy, ex, ey, arrow_size=5, color=None, penwidth=None):
 
-		"""Mimicks canvas api. See openexp._canvas.canvas."""
 
-		a = math.atan2(ey - sy, ex - sx)
-		sx1 = ex + arrow_size * math.cos(a + math.radians(135))
-		sy1 = ey + arrow_size * math.sin(a + math.radians(135))
-		sx2 = ex + arrow_size * math.cos(a + math.radians(225))
-		sy2 = ey + arrow_size * math.sin(a + math.radians(225))
-		group = QtGui.QGraphicsItemGroup()
-		i = self.line(sx, sy, ex, ey, color=color, penwidth=penwidth,
-			add=False)
-		group.addToGroup(i)
-		i = self.line(sx1, sy1, ex, ey, color=color, penwidth=penwidth,
-			add=False)
-		group.addToGroup(i)
-		i = self.line(sx2, sy2, ex, ey, color=color, penwidth=penwidth,
-			add=False)
-		group.addToGroup(i)
-		self.addItem(group)
-		return group
 
+	def arrow(self,sx,sy,ex,ey,proportion = 0.7, arrow_width = 30,color = None, 
+		fill= False, penwidth = None, add = True):
+		# length
+		d = math.sqrt((ey-sy)**2 + (sx-ex)**2)
+		# direction  
+		angle = math.atan2(ey-sy,ex-sx)
+		
+		p0 = (sx,sy)
+		p4 = (ex,ey)
+
+		p1 = (sx + 0.25 * arrow_width * math.cos(angle - math.pi/2),\
+			sy + 0.25 * arrow_width * math.sin(angle - math.pi/2))
+
+		p2 = (p1[0] + proportion*math.cos(angle) * d, \
+		 	p1[1] + proportion * math.sin(angle) * d)
+		p3 = (p2[0] + 0.25 * arrow_width * math.cos(angle - math.pi/2), \
+			p2[1] + 0.25 * arrow_width * math.sin(angle - math.pi/2))
+		
+		p7 = (sx + 0.25 * arrow_width*math.cos(angle + math.pi/2), \
+			sy + 0.25 * arrow_width*math.sin(angle + math.pi/2))
+		p6 = (p7[0] + proportion * math.cos(angle) * d, \
+		 	p7[1] + proportion * math.sin(angle) * d)
+		p5 = (p6[0] + 0.25 * arrow_width * math.cos(angle + math.pi/2), \
+			p6[1] + 0.25 * arrow_width * math.sin(angle + math.pi/2))
+
+		color = self._color(color)
+		if fill:
+			pen = self._pen(color, 1)
+			brush = self._brush(color)
+		else:
+			pen = self._pen(color, penwidth)
+			brush = QtGui.QBrush()
+		polygon = QtGui.QPolygonF()
+		for point in [p0,p1, p2,p3,p4,p5,p6,p7]:
+			polygon <<  QtCore.QPointF(point[0],point[1])
+		i = QtGui.QGraphicsPolygonItem(polygon)
+		i.setPen(pen)
+		i.setBrush(brush)
+		if add:
+			self.addItem(i)
+		return i
+		
 	def rect(self, x, y, w, h, fill=False, color=None, penwidth=None):
 
 		"""Mimicks canvas api. See openexp._canvas.canvas."""

--- a/libqtopensesame/sketchpad_elements/_arrow.py
+++ b/libqtopensesame/sketchpad_elements/_arrow.py
@@ -20,6 +20,9 @@ along with openexp.  If not, see <http://www.gnu.org/licenses/>.
 from libqtopensesame.sketchpad_elements._base_line_arrow import base_line_arrow
 from libopensesame.sketchpad_elements import arrow as arrow_runtime
 
+
+
+
 class arrow(base_line_arrow, arrow_runtime):
 
 	"""
@@ -47,7 +50,9 @@ class arrow(base_line_arrow, arrow_runtime):
 				u'y2':		pos[1],
 				u'color': 	sketchpad.current_color(),
 				u'penwidth'	: sketchpad.current_penwidth(),
-				u'arrow_size'	: sketchpad.current_arrow_size(),
+				u'proportion'	: sketchpad.current_proportion(),
+				u'arrow_width'	: sketchpad.current_arrow_width(),
+				u'fill'		: sketchpad.current_fill(),
 				u'show_if'	: sketchpad.current_show_if()
 			}
 		e = arrow(sketchpad, properties=properties)
@@ -56,5 +61,14 @@ class arrow(base_line_arrow, arrow_runtime):
 		return e
 
 	@staticmethod
-	def requires_arrow_size():
+	def requires_arrow_width():
 		return True
+
+	@staticmethod
+	def requires_proportion():
+		return True
+
+	@staticmethod
+	def requires_fill():
+		return True
+

--- a/libqtopensesame/sketchpad_elements/_arrow.py
+++ b/libqtopensesame/sketchpad_elements/_arrow.py
@@ -20,9 +20,6 @@ along with openexp.  If not, see <http://www.gnu.org/licenses/>.
 from libqtopensesame.sketchpad_elements._base_line_arrow import base_line_arrow
 from libopensesame.sketchpad_elements import arrow as arrow_runtime
 
-
-
-
 class arrow(base_line_arrow, arrow_runtime):
 
 	"""
@@ -44,16 +41,17 @@ class arrow(base_line_arrow, arrow_runtime):
 			sketchpad.canvas.removeItem(cls.preview)
 			return
 		properties = {
-				u'x1':		cls.pos_start[0],
-				u'y1':		cls.pos_start[1],
-				u'x2':		pos[0],
-				u'y2':		pos[1],
-				u'color': 	sketchpad.current_color(),
-				u'penwidth'	: sketchpad.current_penwidth(),
-				u'proportion'	: sketchpad.current_proportion(),
-				u'arrow_width'	: sketchpad.current_arrow_width(),
-				u'fill'		: sketchpad.current_fill(),
-				u'show_if'	: sketchpad.current_show_if()
+				u'x1':				cls.pos_start[0],
+				u'y1':				cls.pos_start[1],
+				u'x2':				pos[0],
+				u'y2':				pos[1],
+				u'color': 			sketchpad.current_color(),
+				u'penwidth'	: 		sketchpad.current_penwidth(),
+				u'proportion':		sketchpad.current_proportion(),
+				u'arrow_width':		sketchpad.current_arrow_width(),
+				u'arrowhead_width':	sketchpad.current_arrowhead_width(),
+				u'fill':			sketchpad.current_fill(),
+				u'show_if':			sketchpad.current_show_if()
 			}
 		e = arrow(sketchpad, properties=properties)
 		cls.pos_start = None
@@ -62,6 +60,10 @@ class arrow(base_line_arrow, arrow_runtime):
 
 	@staticmethod
 	def requires_arrow_width():
+		return True
+
+	@staticmethod
+	def requires_arrowhead_width():
 		return True
 
 	@staticmethod

--- a/libqtopensesame/sketchpad_elements/_base_element.py
+++ b/libqtopensesame/sketchpad_elements/_base_element.py
@@ -450,6 +450,19 @@ class base_element(object):
 		return False
 
 	@staticmethod
+	def requires_arrowhead_width():
+
+		"""
+		desc:
+			Indicates whether the element requires arrowhead_width settings.
+
+		returns:
+			type:	bool
+		"""
+
+		return False
+
+	@staticmethod
 	def requires_scale():
 
 		"""
@@ -461,6 +474,7 @@ class base_element(object):
 		"""
 
 		return False
+		
 	@staticmethod
 	def requires_fill():
 

--- a/libqtopensesame/sketchpad_elements/_base_element.py
+++ b/libqtopensesame/sketchpad_elements/_base_element.py
@@ -424,6 +424,32 @@ class base_element(object):
 		return False
 
 	@staticmethod
+	def requires_proportion():
+
+		"""
+		desc:
+			Indicates whether the element requires arrow-proportion settings.
+
+		returns:
+			type:	bool
+		"""
+
+		return False
+		
+	@staticmethod
+	def requires_arrow_width():
+
+		"""
+		desc:
+			Indicates whether the element requires arrow_width settings.
+
+		returns:
+			type:	bool
+		"""
+
+		return False
+
+	@staticmethod
 	def requires_scale():
 
 		"""
@@ -435,7 +461,6 @@ class base_element(object):
 		"""
 
 		return False
-
 	@staticmethod
 	def requires_fill():
 

--- a/libqtopensesame/widgets/sketchpad_widget.py
+++ b/libqtopensesame/widgets/sketchpad_widget.py
@@ -62,7 +62,8 @@ class sketchpad_widget(base_widget):
 		self.ui.spinbox_arrow_size.valueChanged.connect(self.apply_arrow_size)
 		self.ui.spinbox_proportion.valueChanged.connect(self.apply_proportion)
 		self.ui.spinbox_arrow_width.valueChanged.connect(self.apply_arrow_width)
-
+		self.ui.spinbox_arrowhead_width.valueChanged.connect(\
+			self.apply_arrowhead_width)
 		self.ui.checkbox_center.toggled.connect(self.apply_center)
 		self.ui.checkbox_fill.toggled.connect(self.apply_fill)
 		self.ui.checkbox_html.toggled.connect(self.apply_html)
@@ -211,18 +212,29 @@ class sketchpad_widget(base_widget):
 
 		"""
 		desc:
-			Applies changes to the arrow_size spinbox.
+			Applies changes to the arrow_width spinbox.
 		"""
 
 		for element in self.sketchpad.selected_elements():
 			element.set_property(u'arrow_width', arrow_width)
 		self.draw()
 
+	def apply_arrowhead_width(self, arrowhead_width):
+
+		"""
+		desc:
+			Applies changes to the arrow_width spinbox.
+		"""
+
+		for element in self.sketchpad.selected_elements():
+			element.set_property(u'arrowhead_width', arrowhead_width)
+		self.draw()
+
 	def apply_proportion(self, proportion):
 
 		"""
 		desc:
-			Applies changes to the arrow_size spinbox.
+			Applies changes to the arrow_proportion spinbox.
 		"""
 
 		for element in self.sketchpad.selected_elements():
@@ -259,6 +271,9 @@ class sketchpad_widget(base_widget):
 		if element.requires_arrow_width():
 			self.ui.spinbox_arrow_width.setValue(element.get_property(
 				u'arrow_width', _type=int))
+		if element.requires_arrowhead_width():
+			self.ui.spinbox_arrowhead_width.setValue(element.get_property(
+				u'arrowhead_width', _type=float))
 		if element.requires_proportion():
 			self.ui.spinbox_proportion.setValue(element.get_property(
 				u'proportion', _type=float))
@@ -366,6 +381,7 @@ class sketchpad_widget(base_widget):
 		self.ui.widget_settings_penwidth.setVisible(False)
 		self.ui.widget_settings_arrow_size.setVisible(False)
 		self.ui.widget_settings_arrow_width.setVisible(False)
+		self.ui.widget_settings_arrowhead_width.setVisible(False)
 		self.ui.widget_settings_proportion.setVisible(False)
 		self.ui.widget_settings_scale.setVisible(False)
 		self.ui.widget_settings_fill.setVisible(False)
@@ -414,6 +430,8 @@ class sketchpad_widget(base_widget):
 			element.requires_arrow_size())
 		self.ui.widget_settings_arrow_width.setVisible(
 			element.requires_arrow_width())
+		self.ui.widget_settings_arrowhead_width.setVisible(
+			element.requires_arrowhead_width())
 		self.ui.widget_settings_proportion.setVisible(
 			element.requires_proportion())
 		self.ui.widget_settings_scale.setVisible(element.requires_scale())
@@ -539,17 +557,27 @@ class sketchpad_widget(base_widget):
 
 		"""
 		returns:
-			desc:	The current arrow size.
+			desc:	The current arrow width.
 			type:	int
 		"""
 
 		return self.ui.spinbox_arrow_width.value()
 
+	def current_arrowhead_width(self):
+
+		"""
+		returns:
+			desc:	The current arrowhead width.
+			type:	float
+		"""
+
+		return self.ui.spinbox_arrowhead_width.value()
+
 	def current_proportion(self):
 
 		"""
 		returns:
-			desc:	The current arrow size.
+			desc:	The current arrow proportions.
 			type:	int
 		"""
 

--- a/libqtopensesame/widgets/sketchpad_widget.py
+++ b/libqtopensesame/widgets/sketchpad_widget.py
@@ -60,6 +60,9 @@ class sketchpad_widget(base_widget):
 		self.ui.edit_color.textEdited.connect(self.apply_color)
 		self.ui.edit_show_if.editingFinished.connect(self.apply_show_if)
 		self.ui.spinbox_arrow_size.valueChanged.connect(self.apply_arrow_size)
+		self.ui.spinbox_proportion.valueChanged.connect(self.apply_proportion)
+		self.ui.spinbox_arrow_width.valueChanged.connect(self.apply_arrow_width)
+
 		self.ui.checkbox_center.toggled.connect(self.apply_center)
 		self.ui.checkbox_fill.toggled.connect(self.apply_fill)
 		self.ui.checkbox_html.toggled.connect(self.apply_html)
@@ -203,6 +206,28 @@ class sketchpad_widget(base_widget):
 		for element in self.sketchpad.selected_elements():
 			element.set_property(u'arrow_size', arrow_size)
 		self.draw()
+	
+	def apply_arrow_width(self, arrow_width):
+
+		"""
+		desc:
+			Applies changes to the arrow_size spinbox.
+		"""
+
+		for element in self.sketchpad.selected_elements():
+			element.set_property(u'arrow_width', arrow_width)
+		self.draw()
+
+	def apply_proportion(self, proportion):
+
+		"""
+		desc:
+			Applies changes to the arrow_size spinbox.
+		"""
+
+		for element in self.sketchpad.selected_elements():
+			element.set_property(u'proportion', proportion)
+		self.draw()
 
 	def show_element_settings(self, element):
 
@@ -231,6 +256,12 @@ class sketchpad_widget(base_widget):
 		if element.requires_arrow_size():
 			self.ui.spinbox_arrow_size.setValue(element.get_property(
 				u'arrow_size', _type=int))
+		if element.requires_arrow_width():
+			self.ui.spinbox_arrow_width.setValue(element.get_property(
+				u'arrow_width', _type=int))
+		if element.requires_proportion():
+			self.ui.spinbox_proportion.setValue(element.get_property(
+				u'proportion', _type=float))
 		if element.requires_scale():
 			self.ui.spinbox_scale.setValue(element.get_property(u'scale',
 				_type=float))
@@ -334,6 +365,8 @@ class sketchpad_widget(base_widget):
 		self.ui.widget_settings_color.setVisible(False)
 		self.ui.widget_settings_penwidth.setVisible(False)
 		self.ui.widget_settings_arrow_size.setVisible(False)
+		self.ui.widget_settings_arrow_width.setVisible(False)
+		self.ui.widget_settings_proportion.setVisible(False)
 		self.ui.widget_settings_scale.setVisible(False)
 		self.ui.widget_settings_fill.setVisible(False)
 		self.ui.widget_settings_center.setVisible(False)
@@ -379,6 +412,10 @@ class sketchpad_widget(base_widget):
 		self.ui.widget_settings_penwidth.setVisible(element.requires_penwidth())
 		self.ui.widget_settings_arrow_size.setVisible(
 			element.requires_arrow_size())
+		self.ui.widget_settings_arrow_width.setVisible(
+			element.requires_arrow_width())
+		self.ui.widget_settings_proportion.setVisible(
+			element.requires_proportion())
 		self.ui.widget_settings_scale.setVisible(element.requires_scale())
 		self.ui.widget_settings_fill.setVisible(element.requires_fill())
 		self.ui.widget_settings_center.setVisible(element.requires_center())
@@ -497,6 +534,26 @@ class sketchpad_widget(base_widget):
 		"""
 
 		return self.ui.spinbox_arrow_size.value()
+
+	def current_arrow_width(self):
+
+		"""
+		returns:
+			desc:	The current arrow size.
+			type:	int
+		"""
+
+		return self.ui.spinbox_arrow_width.value()
+
+	def current_proportion(self):
+
+		"""
+		returns:
+			desc:	The current arrow size.
+			type:	int
+		"""
+
+		return self.ui.spinbox_proportion.value()
 
 	def current_fill(self):
 

--- a/openexp/_canvas/canvas.py
+++ b/openexp/_canvas/canvas.py
@@ -596,35 +596,43 @@ class canvas(object):
 
 		raise NotImplementedError()
 
-	def arrow(self, sx, sy, ex, ey, arrow_size=5, color=None, penwidth=None):
+
+	def arrow(self,sx,sy,ex,ey,proportion = 0.7, arrow_width = 30,color = None, 
+		fill= False, penwidth = None):
 
 		"""
 		desc:
-			Draws an arrow. An arrow is a line, with an arrowhead at (ex, ey).
-			The angle between the arrowhead lines and the arrow line is 45
-			degrees.
+			Draws an arrow. An arrow is a polygon consisting of 7 vertices,
+			with an arrowhead pointing at (ex, ey). 
 
 		arguments:
 			sx:
-				desc:	The left X coordinate.
+				desc:	The X coordinate of the arrow's base.
 				type:	int
 			sy:
-				desc:	The top Y coordinate.
+				desc:	The Y coordinate of the arrow's base.
 				type:	int
 			ex:
-				desc:	The right X coordinate.
+				desc:	The X coordinate of the arrow's tip.
 				type:	int
 			ey:
-				desc:	The bottom Y coordinate.
+				desc:	The Y coordinate of the arrow's tip..
 				type:	int
 
 		keywords:
-			arrow_size:
-				desc:	The length of the arrow-head lines in pixels.
-				type:	int
+			proportion:
+				desc:	Proportion of the arrow body length to the total arrow length
+				type:	float (0,1)
+			arrow_width:
+				desc:	The expansion of the arrow-head perpendicular to the pointing 
+						direction in pixels
+				type:	int (preferably even)
 			color:
 				desc:	"%arg_fgcolor"
 				type:	[str, unicode, NoneType]
+			fill:
+				desc:	"%arg_fill"
+				type:	[bool]				
 			penwidth:
 				desc:	"%arg_penwidth"
 				type:	int
@@ -634,17 +642,47 @@ class canvas(object):
 			my_canvas = canvas(exp)
 			w = self.get('width')/2
 			h = self.get('height')/2
-			my_canvas.arrow(0, 0, w, h, arrow_size=10)
+			my_canvas.arrow(0, 0, w, h, arrow_width=40,proportion = 0.8)
 		"""
 
-		self.line(sx, sy, ex, ey, color=color, penwidth=penwidth)
-		a = math.atan2(ey - sy, ex - sx)
-		_sx = ex + arrow_size * math.cos(a + math.radians(135))
-		_sy = ey + arrow_size * math.sin(a + math.radians(135))
-		self.line(_sx, _sy, ex, ey, color=color, penwidth=penwidth)
-		_sx = ex + arrow_size * math.cos(a + math.radians(225))
-		_sy = ey + arrow_size * math.sin(a + math.radians(225))
-		self.line(_sx, _sy, ex, ey, color=color, penwidth=penwidth)
+		# length 
+		d = math.sqrt((ey-sy)**2 + (sx-ex)**2)
+		# direction  
+		angle = math.atan2(ey-sy,ex-sx)
+
+
+		# calculate points between each of the vertices, according to this scheme
+		#    3	
+		#    |\
+		#    | \
+		# 1--2  \
+        # |      \
+		# 0	      4
+		# |		 /
+		# 7--6  /
+		#    | /
+		#    |/	
+		#    5
+		p0 = (sx,sy)
+		p4 = (ex,ey)
+
+		p1 = (sx + 0.25 * arrow_width * math.cos(angle - math.pi/2),\
+			sy + 0.25 * arrow_width * math.sin(angle - math.pi/2))
+
+		p2 = (p1[0] + proportion*math.cos(angle) * d, \
+		 	p1[1] + proportion * math.sin(angle) * d)
+		p3 = (p2[0] + 0.25 * arrow_width * math.cos(angle - math.pi/2), \
+			p2[1] + 0.25 * arrow_width * math.sin(angle - math.pi/2))
+		
+		p7 = (sx + 0.25 * arrow_width*math.cos(angle + math.pi/2), \
+			sy + 0.25 * arrow_width*math.sin(angle + math.pi/2))
+		p6 = (p7[0] + proportion * math.cos(angle) * d, \
+		 	p7[1] + proportion * math.sin(angle) * d)
+		p5 = (p6[0] + 0.25 * arrow_width * math.cos(angle + math.pi/2), \
+			p6[1] + 0.25 * arrow_width * math.sin(angle + math.pi/2))
+
+		self.polygon([p0,p1,p2,p3,p4,p5,p6,p7], color = color, fill = fill, penwidth = penwidth)
+
 
 	def rect(self, x, y, w, h, fill=False, color=None, penwidth=None):
 

--- a/openexp/_canvas/canvas.py
+++ b/openexp/_canvas/canvas.py
@@ -596,9 +596,8 @@ class canvas(object):
 
 		raise NotImplementedError()
 
-
-	def arrow(self,sx,sy,ex,ey,proportion = 0.7, arrow_width = 30,color = None, 
-		fill= False, penwidth = None):
+	def arrow(self, sx, sy, ex, ey, proportion=0.7, arrow_width=30,
+		arrowhead_width=0.5, color=None, fill=False, penwidth=None):
 
 		"""
 		desc:
@@ -621,12 +620,17 @@ class canvas(object):
 
 		keywords:
 			proportion:
-				desc:	Proportion of the arrow body length to the total arrow length
+				desc:	Proportion of the arrow body length to the total 
+						arrow length
 				type:	float (0,1)
 			arrow_width:
-				desc:	The expansion of the arrow-head perpendicular to the pointing 
-						direction in pixels
+				desc:	The expansion of the arrow perpendicular to 
+						the pointing direction in pixels
 				type:	int (preferably even)
+			arrowhead_width:
+				desc:	The proportion of width of arrowhead to total arrow 
+						width
+				type:	float (0,1)
 			color:
 				desc:	"%arg_fgcolor"
 				type:	[str, unicode, NoneType]
@@ -649,39 +653,25 @@ class canvas(object):
 		d = math.sqrt((ey-sy)**2 + (sx-ex)**2)
 		# direction  
 		angle = math.atan2(ey-sy,ex-sx)
-
-
-		# calculate points between each of the vertices, according to this scheme
-		#    3	
-		#    |\
-		#    | \
-		# 1--2  \
-        # |      \
-		# 0	      4
-		# |		 /
-		# 7--6  /
-		#    | /
-		#    |/	
-		#    5
+		head_width = arrowhead_width/2.0 
+		body_width = (1-arrowhead_width)/2.0 
+		# calculate coordinates
 		p0 = (sx,sy)
 		p4 = (ex,ey)
-
-		p1 = (sx + 0.25 * arrow_width * math.cos(angle - math.pi/2),\
-			sy + 0.25 * arrow_width * math.sin(angle - math.pi/2))
-
+		p1 = (sx +body_width * arrow_width * math.cos(angle - math.pi/2),\
+			sy + body_width * arrow_width * math.sin(angle - math.pi/2))
 		p2 = (p1[0] + proportion*math.cos(angle) * d, \
 		 	p1[1] + proportion * math.sin(angle) * d)
-		p3 = (p2[0] + 0.25 * arrow_width * math.cos(angle - math.pi/2), \
-			p2[1] + 0.25 * arrow_width * math.sin(angle - math.pi/2))
-		
-		p7 = (sx + 0.25 * arrow_width*math.cos(angle + math.pi/2), \
-			sy + 0.25 * arrow_width*math.sin(angle + math.pi/2))
+		p3 = (p2[0]+head_width * arrow_width * math.cos(angle-math.pi/2),\
+			p2[1] + head_width * arrow_width * math.sin(angle-math.pi/2))
+		p7 = (sx + body_width * arrow_width*math.cos(angle + math.pi/2),\
+			sy + body_width * arrow_width*math.sin(angle + math.pi/2))
 		p6 = (p7[0] + proportion * math.cos(angle) * d, \
 		 	p7[1] + proportion * math.sin(angle) * d)
-		p5 = (p6[0] + 0.25 * arrow_width * math.cos(angle + math.pi/2), \
-			p6[1] + 0.25 * arrow_width * math.sin(angle + math.pi/2))
-
-		self.polygon([p0,p1,p2,p3,p4,p5,p6,p7], color = color, fill = fill, penwidth = penwidth)
+		p5 = (p6[0]+head_width * arrow_width * math.cos(angle+math.pi/2),\
+			p6[1]+head_width * arrow_width * math.sin(angle+math.pi/2))
+		self.polygon([p0,p1,p2,p3,p4,p5,p6,p7], color=color, fill=fill, \
+			penwidth=penwidth)
 
 
 	def rect(self, x, y, w, h, fill=False, color=None, penwidth=None):

--- a/resources/ui/widgets/sketchpad.ui
+++ b/resources/ui/widgets/sketchpad.ui
@@ -148,8 +148,7 @@
             </item>
            </layout>
           </widget>
-         </item>
-         
+         </item>  
          <item>
           <widget class="QWidget" name="widget_settings_arrow_size" native="true">
            <layout class="QHBoxLayout" name="horizontalLayout_9">
@@ -191,7 +190,53 @@
            </layout>
           </widget>
          </item>
-
+         <item>
+          <widget class="QWidget" name="widget_settings_arrowhead_width" native="true">
+           <layout class="QHBoxLayout" name="horizontalLayout_9">
+            <property name="margin">
+             <number>0</number>
+            </property>
+            <item>
+             <widget class="QFrame" name="frame_5">
+              <property name="frameShape">
+               <enum>QFrame::VLine</enum>
+              </property>
+              <property name="frameShadow">
+               <enum>QFrame::Raised</enum>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QDoubleSpinBox" name="spinbox_arrowhead_width">
+              <property name="toolTip">
+               <string>Width of the arrowhead</string>
+              </property>
+              <property name="suffix">
+               <string> px</string>
+              </property>
+              <property name="prefix">
+               <string>Arrowhead width</string>
+              </property>
+              <property name="decimals">
+               <number>2</number>
+              </property>
+              <property name="singleStep">
+               <double>0.0500</double>
+              </property>
+              <property name="minimum">
+               <double>0.0</double>
+              </property>
+              <property name="maximum">
+               <double>1.0</double>
+              </property>
+              <property name="value">
+               <double>0.5</double>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+         </item>
          <item>
           <widget class="QWidget" name="widget_settings_arrow_width" native="true">
            <layout class="QHBoxLayout" name="horizontalLayout_9">
@@ -217,7 +262,7 @@
                <string> px</string>
               </property>
               <property name="prefix">
-               <string>Arrowwidth </string>
+               <string>Arrow width </string>
               </property>
               <property name="minimum">
                <number>1</number>
@@ -233,7 +278,6 @@
            </layout>
           </widget>
          </item>
-
          <item>
           <widget class="QWidget" name="widget_settings_proportion" native="true">
            <layout class="QHBoxLayout" name="horizontalLayout_9">

--- a/resources/ui/widgets/sketchpad.ui
+++ b/resources/ui/widgets/sketchpad.ui
@@ -149,6 +149,7 @@
            </layout>
           </widget>
          </item>
+         
          <item>
           <widget class="QWidget" name="widget_settings_arrow_size" native="true">
            <layout class="QHBoxLayout" name="horizontalLayout_9">
@@ -190,6 +191,94 @@
            </layout>
           </widget>
          </item>
+
+         <item>
+          <widget class="QWidget" name="widget_settings_arrow_width" native="true">
+           <layout class="QHBoxLayout" name="horizontalLayout_9">
+            <property name="margin">
+             <number>0</number>
+            </property>
+            <item>
+             <widget class="QFrame" name="frame_5">
+              <property name="frameShape">
+               <enum>QFrame::VLine</enum>
+              </property>
+              <property name="frameShadow">
+               <enum>QFrame::Raised</enum>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QSpinBox" name="spinbox_arrow_width">
+              <property name="toolTip">
+               <string>Width of the arrow</string>
+              </property>
+              <property name="suffix">
+               <string> px</string>
+              </property>
+              <property name="prefix">
+               <string>Arrowwidth </string>
+              </property>
+              <property name="minimum">
+               <number>1</number>
+              </property>
+              <property name="maximum">
+               <number>1000</number>
+              </property>
+              <property name="value">
+               <number>30</number>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+         </item>
+
+         <item>
+          <widget class="QWidget" name="widget_settings_proportion" native="true">
+           <layout class="QHBoxLayout" name="horizontalLayout_9">
+            <property name="margin">
+             <number>0</number>
+            </property>
+            <item>
+             <widget class="QFrame" name="frame_5">
+              <property name="frameShape">
+               <enum>QFrame::VLine</enum>
+              </property>
+              <property name="frameShadow">
+               <enum>QFrame::Raised</enum>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QDoubleSpinBox" name="spinbox_proportion">
+              <property name="toolTip">
+               <string>Proportion of base to head</string>
+              </property>
+              <property name="prefix">
+               <string>Proportion </string>
+              </property>
+              <property name="minimum">
+               <double>0.0</double>
+              </property>
+              <property name="maximum">
+               <double>1.0</double>
+              </property>
+              <property name="decimals">
+               <number>2</number>
+              </property>
+              <property name="singleStep">
+               <double>0.0500</double>
+              </property>
+              <property name="value">
+               <double>0.8</double>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+         </item>
+
          <item>
           <widget class="QWidget" name="widget_settings_scale" native="true">
            <layout class="QHBoxLayout" name="horizontalLayout_10">


### PR DESCRIPTION
This includes drawing from within a `sketchpad` and also drawing by creating a `canvas` object from within an `inline_script`. 
The new arrow is a polygon with seven vertices. It has two new features (arrow width and proportion of body to head length) that needed to be created to appear in the `sketchpad` item. 
