### PR TITLE
Fixed 'NoneType' has no len() error

### DIFF
--- a/plugins/text_input/text_input.py
+++ b/plugins/text_input/text_input.py
@@ -135,7 +135,7 @@ class text_input(item.item, generic_response.generic_response):
 
 			# Get the response and the moderators (shift etc.)
 			resp, time = self._keyboard.get_key()
-			if len(resp) == 1:
+			if resp!=None and len(resp) == 1:
 				o = ord(resp)
 			else:
 				o = -1
@@ -149,7 +149,7 @@ class text_input(item.item, generic_response.generic_response):
 					response = response[:-1]
 			elif resp == "space":
 				response += " "
-			elif len(resp) == 1:
+			elif resp!=None and len(resp) == 1:
 				response += resp
 
 		self.experiment.set("response", self.experiment.sanitize(response))

--- a/plugins/text_input/text_input.py
+++ b/plugins/text_input/text_input.py
@@ -134,7 +134,7 @@ class text_input(item.item, generic_response.generic_response):
 			c.show()
 
 			# Get the response and the moderators (shift etc.)
-			resp, time = self._keyboard.get_key()
+			resp, time = self._keyboard.get_key(keylist=None, timeout=0)
 			if resp!=None and len(resp) == 1:
 				o = ord(resp)
 			else:


### PR DESCRIPTION
Because self.timeout is now correctly passed to self._keyboard (because of Klemtonius fix: Fixed timeout function for text_input item). The while true loop tried to process the keyboard response after the timeout. Even when Accept on return press (only) was selected. No this goes well because the while loop doesn't try to get the length of a 'None' response anymore.