### PR TITLE
Added CFBundleDocumentTypes to (Info.)plist

### DIFF
--- a/setup-mac.py
+++ b/setup-mac.py
@@ -20,7 +20,7 @@ along with OpenSesame.  If not, see <http://www.gnu.org/licenses/>.
 This scripts builds OpenSesame as a standalone application for Mac OS.
 
 Usage:
-    python setup.py py2app
+    python setup-mac.py py2app
 """
 
 from setuptools import setup
@@ -69,11 +69,24 @@ setup(
 			 'iconfile' : 'resources/opensesame.icns',
 			 'plist': {
 				'CFBundleName': 'OpenSesame',
-				'CFBundleShortVersionString':'2.9.4',
-				'CFBundleVersion': '2.9.4',
+				'CFBundleShortVersionString':'2.9.7',
+				'CFBundleVersion': '2.9.7',
 				'CFBundleIdentifier':'nl.cogsci.osdoc',
 				'NSHumanReadableCopyright': 'Sebastiaan Mathot (2010-2015)',
 				'CFBundleDevelopmentRegion': 'English', 	
+				'CFBundleDocumentTypes': [ 
+					{
+                    			'CFBundleTypeExtensions' : ['opensesame'],
+                    			'CFBundleTypeIconFile' : 'opensesame.icns',
+                    			'CFBundleTypeRole' : 'Editor',
+                    			'CFBundleTypeName' : 'OpenSesame File',
+					},
+					{
+                    			'CFBundleTypeExtensions' : ['gz'],
+                    			'CFBundleTypeIconFile' : 'opensesame.icns',
+                    			'CFBundleTypeRole' : 'Editor',
+					}
+                                ]
 			}
 		}
 	},


### PR DESCRIPTION
This will assign the OpenSesame icon to .opensesame files and open the Opensesame.app when double clicking on an .opensesame file.
The Opensesame.app will only open (and not open the .opensesame file that was double clicked) because the right Apple Events are not yet included in OpenSesame.
The .gz files are handled by other apps by default on OSX, but this change will add the OpenSesame.app to the menu when right clicking a .opensesame.tar.gz file (or in fact any .gz file).
Also updated Usage comment and version.