### PR TITLE
Fixed invalid list operation OSX

### DIFF
--- a/libopensesame/plugins.py
+++ b/libopensesame/plugins.py
@@ -130,7 +130,10 @@ def plugin_disabled(plugin, _type=u'plugins'):
 	from libqtopensesame.misc import config
 	if plugin_property(plugin, u'disabled', _type=_type):
 		return True
-	if plugin in config.get_config(u'disabled_%s' % _type).split(u';'):
+	# Check if disabled_plugins is not empty in which case it is a 
+	# QPyNullVariant which does not have split() method
+	disabled_plugins = config.get_config(u'disabled_%s' % _type)
+	if hasattr(disabled_plugins, u"split") and plugin in disabled_plugins.split(u';'):
 		return True
 	return False
 

--- a/libqtopensesame/qtopensesame.py
+++ b/libqtopensesame/qtopensesame.py
@@ -353,13 +353,16 @@ class qtopensesame(QtGui.QMainWindow, base_component):
 			cfg.shortcut_tabwidget))
 		self.ui.shortcut_stdout.setKey(QtGui.QKeySequence(cfg.shortcut_stdout))
 		self.ui.shortcut_pool.setKey(QtGui.QKeySequence(cfg.shortcut_pool))
+		
 		# Unpack the string with recent files and only remember those that exist
-		for path in cfg.recent_files.split(u";;"):
-			if os.path.exists(path):
-				debug.msg(u"adding recent file '%s'" % path)
-				self.recent_files.append(path)
-			else:
-				debug.msg(u"missing recent file '%s'" % path)
+		recent_files = cfg.recent_files
+		if hasattr(recent_files, u"split"):
+			for path in recent_files.split(u";;"):
+				if os.path.exists(path):
+					debug.msg(u"adding recent file '%s'" % path)
+					self.recent_files.append(path)
+				else:
+					debug.msg(u"missing recent file '%s'" % path)
 		self.ui.action_enable_auto_response.setChecked(
 			self.experiment.auto_response)
 		self.ui.action_onetabmode.setChecked(cfg.onetabmode)


### PR DESCRIPTION
On OSX a QPyNullVariant is sometimes returned where a string is expected.
The program consequently crashes when it tries to call the split method that is not present. These
extra checks fix this.