### PR TITLE
Fixed Multiprocessing on OSX from Python 3.4

### DIFF
--- a/libqtopensesame/misc/process.py
+++ b/libqtopensesame/misc/process.py
@@ -18,15 +18,15 @@ along with OpenSesame.  If not, see <http://www.gnu.org/licenses/>.
 """
 
 from libopensesame.py3compat import *
-import platform
-# In OS X the multiprocessing module is horribly broken, but a fixed
-# version has been released as the 'billiard' module
-if platform.system() == 'Darwin':
-	import billiard as multiprocessing
-	multiprocessing.forking_enable(0)
+import platform, sys
+
+if platform.system() == 'Darwin' and \
+	sys.version_info[0] < 3:
+		# In OS X Python < 3.4 the multiprocessing module is horribly broken,  
+		# but a fixed version has been released as the 'billiard' module
+		import billiard as multiprocessing
 else:
 	import multiprocessing
-import pickle
 
 class OutputChannel:
 

--- a/libqtopensesame/qtopensesame.py
+++ b/libqtopensesame/qtopensesame.py
@@ -921,7 +921,7 @@ class qtopensesame(QtGui.QMainWindow, base_component):
 		# For the same reason, inOSX the default runner is set to inprocess
 		# for now in misc.config
 		if cfg.runner == u'multiprocess' and sys.platform == "darwin" \
-			and getattr(sys, 'frozen', None):
+			and getattr(sys, 'frozen', None) and sys.version_info < (3,4):
 			self.experiment.notify(u'Multiprocessing does not work in the '
 				u'OSX app version yet. Please change the runner to '
 				u'\'inprocess\' in the preferences panel')

--- a/libqtopensesame/runners/multiprocess_runner.py
+++ b/libqtopensesame/runners/multiprocess_runner.py
@@ -35,7 +35,7 @@ class multiprocess_runner(base_runner):
 
 		import platform
 		if platform.system() == 'Darwin' and \
-			sys.version_info[0] < 3:
+			sys.version_info < (3,4):
 				# In OS X the multiprocessing module is horribly broken, 
 				# for python 2.7 but a fixed version has been released 
 				# as the 'billiard' module

--- a/libqtopensesame/runners/multiprocess_runner.py
+++ b/libqtopensesame/runners/multiprocess_runner.py
@@ -34,11 +34,12 @@ class multiprocess_runner(base_runner):
 		"""See base_runner.execute()."""
 
 		import platform
-		# In OS X the multiprocessing module is horribly broken, but a fixed
-		# version has been released as the 'billiard' module
-		if platform.system() == 'Darwin':
-			import billiard as multiprocessing
-			multiprocessing.forking_enable(0)
+		if platform.system() == 'Darwin' and \
+			sys.version_info[0] < 3:
+				# In OS X the multiprocessing module is horribly broken, 
+				# for python 2.7 but a fixed version has been released 
+				# as the 'billiard' module
+				import billiard as multiprocessing
 		else:
 			import multiprocessing
 

--- a/opensesame
+++ b/opensesame
@@ -31,10 +31,10 @@ if __name__ == u'__main__':
 	# version has been released as the 'billiard' module
 	if platform.system() == 'Darwin':
 		# Use normal multirpocessing module from python 3.4 and on
-		if sys.version_info[0] > 2 and sys.version_info[1] >= 4:
+		if sys.version_info >= (3,4):
 			from multiprocessing import freeze_support, set_start_method
 			freeze_support()
-			set_start_method('spawn')
+			set_start_method('forkserver')
 		else:
 			from billiard import freeze_support, forking_enable
 			freeze_support()

--- a/opensesame
+++ b/opensesame
@@ -30,11 +30,18 @@ if __name__ == u'__main__':
 	# In OS X the multiprocessing module is horribly broken, but a fixed
 	# version has been released as the 'billiard' module
 	if platform.system() == 'Darwin':
-		from billiard import freeze_support, forking_enable
-		forking_enable(0)
+		# Use normal multirpocessing module from python 3.4 and on
+		if sys.version_info[0] > 2 and sys.version_info[1] >= 4:
+			from multiprocessing import freeze_support, set_start_method
+			freeze_support()
+			set_start_method('spawn')
+		else:
+			from billiard import freeze_support, forking_enable
+			freeze_support()
+			forking_enable(0)
 	else:
 		from multiprocessing import freeze_support
-	freeze_support()
+		freeze_support()
 
 	# Change the working directory on Windows. Depending on whether the
 	# application has been frozen by py2exe or not we need to use a different

--- a/setup-mac-py3test.py
+++ b/setup-mac-py3test.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python
+#-*- coding:utf-8 -*-
+
+"""
+This file is part of OpenSesame.
+
+OpenSesame is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+OpenSesame is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with OpenSesame.  If not, see <http://www.gnu.org/licenses/>.
+
+This scripts builds OpenSesame as a standalone application for Mac OS.
+
+Usage:
+    python setup-mac.py py2app
+"""
+
+from setuptools import setup
+import os
+import shutil
+
+from setup_shared  import included_plugins, included_extensions
+
+# Clean up previous builds
+try:
+	shutil.rmtree("dist")
+except:
+	pass
+try:
+	shutil.rmtree("build")
+except:
+	pass
+
+# Copy qt_menu.nib folder
+try:
+	shutil.rmtree("qt_menu.nib")
+except:
+	pass
+shutil.copytree("/usr/local/Frameworks/QtGui.framework/Resources/qt_menu.nib", "qt_menu.nib")
+
+# Py2app doesn't like extensionless Python scripts
+try:
+	os.remove("opensesame.py")
+	os.remove("opensesamerun.py")
+except:
+	pass
+shutil.copyfile("opensesame", "opensesame.py")
+shutil.copyfile("opensesamerun", "opensesamerun.py")
+
+# Build!
+setup(
+    app = ['opensesame.py'],
+    data_files = ['opensesame.py'],
+    options = {'py2app' : 
+		{
+			'argv_emulation': False, 
+			'includes' : [
+				'PyQt4.QtNetwork', 'serial', 'opensesamerun', 'skimage', 'sip'
+			],
+			'excludes': [
+				'Finder','idlelib', 'gtk', 'matplotlib', 'pandas', 'PyQt4.QtDesigner',\
+			 	'PyQt4.QtOpenGL', 'PyQt4.QtScript', 'PyQt4.QtSql', 'PyQt4.QtTest', \
+			 	'PyQt4.QtXml', 'PyQt4.phonon', 'rpy2', 'wx',
+			],
+			'resources' : ['qt_menu.nib', 'resources', 'sounds', 'help', 'data'],
+			'packages' : [
+				'openexp','QProgEdit','libqtopensesame','libopensesame',\
+				'IPython','ipykernel','jupyter_client','qtconsole','pygments',
+			],
+			'iconfile' : 'resources/opensesame.icns',
+			'plist': {
+				'CFBundleName': 'OpenSesame',
+				'CFBundleShortVersionString':'3.0.6',
+				'CFBundleVersion': '3.0.6',
+				'CFBundleIdentifier':'nl.cogsci.osdoc',
+				'NSHumanReadableCopyright': 'Sebastiaan Mathot (2010-2016)',
+				'CFBundleDevelopmentRegion': 'English', 	
+				'CFBundleDocumentTypes': [ 
+					{
+                    	'CFBundleTypeExtensions' : ['osexp'],
+                    	'CFBundleTypeIconFile' : 'resources/opensesame.icns',
+                    	'CFBundleTypeRole' : 'Editor',
+                    	'CFBundleTypeName' : 'OpenSesame File',
+					},
+				]
+			}
+		}
+	},
+   	setup_requires=['py2app'],
+)
+
+# Clean up qt_menu.nib
+shutil.rmtree("qt_menu.nib")
+
+# Psychopy monitor center does not play nicely together with the OpenSesame GUI
+if 'psychopy_monitor_center' in included_extensions:
+	del included_extensions[included_extensions.index('psychopy_monitor_center')]
+
+# Copy extensions into app
+for extension in included_extensions:
+	shutil.copytree(os.path.join("extensions",extension), os.path.join("dist/opensesame.app/Contents/Resources/extensions/",extension))
+
+# Copy plugins into app
+for plugin in included_plugins:
+	shutil.copytree(os.path.join("plugins",plugin), os.path.join("dist/opensesame.app/Contents/Resources/plugins/",plugin))
+
+# Remove opensesame.py
+try:
+	os.remove("opensesame.py")
+	os.remove("opensesamerun.py")
+except:
+	pass


### PR DESCRIPTION
Billiard (taking care of multiprocessing on OSX) no longer worked under Python 3, but the good news is, that the native Python 3 multiprocessing package does the job perfectly and better than billiard ever did. Hopefully it will also make multiprocessing possible for the app versions of OpenSesame!