### PR TITLE
Fixes to let OpenSesame work with Qt 5.6

### DIFF
--- a/libopensesame/misc.py
+++ b/libopensesame/misc.py
@@ -389,4 +389,11 @@ if hasattr(site, u'getsitepackages'):
 		[os.path.join(safe_decode(folder, enc=filesystem_encoding()), u'share') \
 		for folder in site.getsitepackages()]
 base_folders += [u'/usr/local/share', u'/usr/share']
+# Locate Anaconda/Miniconda share
+if any(entry in sys.executable.lower() for entry in ['anaconda','miniconda']):
+	base_folders.append(os.path.join(
+		safe_decode(
+			os.path.dirname(os.path.dirname(sys.executable)),
+			enc=filesystem_encoding()), 
+		u"share"))
 base_folders = list(filter(os.path.exists, base_folders))

--- a/libqtopensesame/__main__.py
+++ b/libqtopensesame/__main__.py
@@ -50,12 +50,21 @@ def opensesame():
 	parse_environment_file()
 	# Force the new-style Qt API
 	import sip
+	import qtpy
 	sip.setapi('QString', 2)
 	sip.setapi('QVariant', 2)
 	# Load debug package (this must be after the working directory change)
 	from libopensesame import debug
 	# Do the basic window initialization
 	from qtpy.QtWidgets import QApplication
+
+	# From Qt 5.6 on, QtWebEngine is the default way to render web pages
+	# QtWebEngineWidgets must be imported before a QCoreApplication instance is created
+	try:
+		from qtpy import QtWebEngineWidgets
+	except ImportError:
+		pass
+	
 	app = QApplication(sys.argv)
 	from libqtopensesame.qtopensesame import qtopensesame
 	opensesame = qtopensesame(app)

--- a/libqtopensesame/qtopensesame.py
+++ b/libqtopensesame/qtopensesame.py
@@ -269,11 +269,12 @@ class qtopensesame(QtWidgets.QMainWindow, base_component):
 			except:
 				ttf = None
 				debug.msg(u'failed to find %s' % font)
-			if ttf is not None:
+			else:
 				debug.msg(u'registering %s (%s)' % (font, ttf))
 				id = QtGui.QFontDatabase.addApplicationFont(ttf)
-				family = QtGui.QFontDatabase.applicationFontFamilies(id)[0]
-				QtGui.QFont.insertSubstitution(font, family)
+				families = QtGui.QFontDatabase.applicationFontFamilies(id)
+				if families:
+					QtGui.QFont.insertSubstitution(font, families[0])
 
 
 	def parse_command_line(self):

--- a/libqtopensesame/qtopensesame.py
+++ b/libqtopensesame/qtopensesame.py
@@ -267,7 +267,6 @@ class qtopensesame(QtWidgets.QMainWindow, base_component):
 			try:
 				ttf = self.experiment.resource(u'%s.ttf' % font)
 			except:
-				ttf = None
 				debug.msg(u'failed to find %s' % font)
 			else:
 				debug.msg(u'registering %s (%s)' % (font, ttf))

--- a/libqtopensesame/widgets/webbrowser.py
+++ b/libqtopensesame/widgets/webbrowser.py
@@ -109,11 +109,9 @@ class small_webpage(WebPage):
 		# of received arguments can be determined.
 		if isinstance(args[0], QtCore.QUrl):
 			url, navtype, isMainFrame = args
-			mode = 'QtWebEngine'
 		else:
 			frame, request, navtype = args
 			url = request.url()
-			mode = 'QtWebKit'
 
 		if navtype == self.NavigationTypeLinkClicked:			
 			url = url.toString()
@@ -126,13 +124,8 @@ class small_webpage(WebPage):
 			if url.startswith(u'http://osdoc.cogsci.nl'):
 				self.parent().load(url)
 				return False
-				
-			# QtWebEngine already opens URLs in a platform specific way
-			# automatically. This does not need to be handeled by OpenSesame.
-			if mode == 'QtWebKit':
-				misc.open_url(url)
-			else:
-				return super(small_webpage, self).acceptNavigationRequest(*args)
+			misc.open_url(url)
+			return False
 		else:
 			return super(small_webpage, self).acceptNavigationRequest(*args)
 

--- a/libqtopensesame/widgets/webbrowser.py
+++ b/libqtopensesame/widgets/webbrowser.py
@@ -27,11 +27,18 @@ import os.path
 
 import os
 if os.environ[u'QT_API'] == u'pyqt':
-	from PyQt4 import QtWebKit
+	from PyQt4.QtWebKit import QWebView as WebView
+	from PyQt4.QtWebKit import QWebPage as WebPage
 else:
-	from PyQt5 import QtWebKitWidgets as QtWebKit
+	# QtWebKit is dropped in favour of QtWebEngine from Qt 5.6 on
+	try:	
+		from PyQt5.QtWebKitWidgets import QWebView as WebView
+		from PyQt5.QtWebKitWidgets import QWebPage as WebPage
+	except ImportError as e:
+		from PyQt5.QtWebEngineWidgets import QWebEngineView as WebView
+		from PyQt5.QtWebEngineWidgets import QWebEnginePage as WebPage
 
-class small_webview(QtWebKit.QWebView):
+class small_webview(WebView):
 
 	"""
 	desc:
@@ -50,6 +57,84 @@ class small_webview(QtWebKit.QWebView):
 		"""
 
 		return QtCore.QSize(100,100)
+
+class small_webpage(WebPage):
+
+	"""
+	desc:
+		A wrapper around QWeb(Engine)Page, to overload the acceptNavigationRequest
+		function, which determines what needs to be done after a link is clicked.
+	"""
+
+	def acceptNavigationRequest(self, *args):
+
+		"""
+		desc:
+			Handles navigation requests to the browser, which can originate from
+			link clicks, or other sources. the arguments and their order differ
+			with the web browser backend being used, which can be QtWebKit or the
+			newer QtWebEngine.
+
+			Arguments (when used by QtWebKit):
+				frame: 			
+					desc: 	The frame that has to be changed depending on the 
+							request
+					type: 	QtWebKit.QWebFrame 
+				request: 		
+					desc:	request containing information about the
+							navigation request, among which the url to change the
+							frame to.
+					type: 	QtWebKit.QNetworkRequest
+				navtype: 		
+					desc: 	type of request has been received (such as link 
+							clicked, form submitted)
+					type: 	QtWebKit.NavigationType
+
+			Arguments (when used by QtWebEngine):
+				url: 			
+					desc: 	url to navigate to
+					type: 	QtCore.QUrl
+				navtype: 		
+					desc: 	type of request has been received (such as link 
+							clicked, form submitted)	
+					type: 	QtWebEngine.NavigationType
+				isMainFrame: 	 
+					desc: 	indicating whether the request corresponds 
+							to the main frame or a child frame.
+					type: 	boolean
+		"""
+
+		# Check if the first argument is a QUrl. If so, then
+		# QWebEngine is used, if not, then QWebKit must be used. This way, the order
+		# of received arguments can be determined.
+		if isinstance(args[0], QtCore.QUrl):
+			url, navtype, isMainFrame = args
+			mode = 'QtWebEngine'
+		else:
+			frame, request, navtype = args
+			url = request.url()
+			mode = 'QtWebKit'
+
+		if navtype == self.NavigationTypeLinkClicked:			
+			url = url.toString()
+			if url.startswith(u'opensesame://'):
+				self.parent().command(url)
+				return False
+			if url.startswith(u'new:'):
+				self.parent().main_window.tabwidget.open_browser(url[4:])
+				return False
+			if url.startswith(u'http://osdoc.cogsci.nl'):
+				self.parent().load(url)
+				return False
+				
+			# QtWebEngine already opens URLs in a platform specific way
+			# automatically. This does not need to be handeled by OpenSesame.
+			if mode == 'QtWebKit':
+				misc.open_url(url)
+			else:
+				return super(small_webpage, self).acceptNavigationRequest(*args)
+		else:
+			return super(small_webpage, self).acceptNavigationRequest(*args)
 
 class webbrowser(base_widget):
 
@@ -71,6 +156,9 @@ class webbrowser(base_widget):
 		super(webbrowser, self).__init__(main_window,
 			ui=u'widgets.webbrowser_widget')
 		self.ui.webview = small_webview(self)
+		# Set webpage which handles link clicks
+		webpage = small_webpage(self)
+		self.ui.webview.setPage(webpage)
 		# Touch events are enabled by default, and this has the effect that
 		# touch events are broken for all other widgets once the webbrowser has
 		# been used. This affects at least Ubuntu 15.05.
@@ -79,7 +167,6 @@ class webbrowser(base_widget):
 		self.ui.webview.loadStarted.connect(self.load_started)
 		self.ui.webview.loadFinished.connect(self.load_finished)
 		self.ui.webview.urlChanged.connect(self.url_changed)
-		self.ui.webview.linkClicked.connect(self.link_clicked)
 		self.ui.layout_main.addWidget(self.ui.webview)
 		self.ui.button_back.clicked.connect(self.ui.webview.back)
 		self.ui.button_osdoc.clicked.connect(self.open_osdoc)
@@ -108,8 +195,6 @@ class webbrowser(base_widget):
 			return
 		self.ui.top_widget.show()
 		self.ui.webview.load(QtCore.QUrl(url))
-		self.ui.webview.page().setLinkDelegationPolicy(
-			self.ui.webview.page().DelegateAllLinks)
 
 	def load_markdown(self, md):
 
@@ -123,8 +208,6 @@ class webbrowser(base_widget):
 
 		self.ui.top_widget.hide()
 		self.ui.webview.setHtml(self.markdown_parser.to_html(md))
-		self.ui.webview.page().setLinkDelegationPolicy(
-			self.ui.webview.page().DelegateAllLinks)
 
 	def load_finished(self):
 
@@ -185,31 +268,6 @@ class webbrowser(base_widget):
 		"""
 
 		self.ui.edit_url.setText(url.toString())
-
-	def link_clicked(self, url):
-
-		"""
-		desc:
-			Process link-clicks to capture special URLs.
-
-		arguments:
-			url:
-				type:	QUrl
-		"""
-
-		url = url.toString()
-		if url.startswith(u'opensesame://'):
-			self.command(url)
-			return
-		if url.startswith(u'new:'):
-			wb = webbrowser(self.main_window)
-			wb.load(url[4:])
-			self.main_window.tabwidget.open_browser(url[4:])
-			return
-		if url.startswith(u'http://osdoc.cogsci.nl'):
-			self.load(url)
-			return
-		misc.open_url(url)
 
 	def command(self, cmd):
 

--- a/opensesame
+++ b/opensesame
@@ -19,4 +19,8 @@ along with OpenSesame.  If not, see <http://www.gnu.org/licenses/>.
 """
 
 from libqtopensesame import __main__
-__main__.opensesame()
+
+# checking if __name__ is __main__ is required to let multiprocessing correctly
+# work on Windows (or any other platform that is not able to use os.fork)
+if __name__ == "__main__":
+	__main__.opensesame()


### PR DESCRIPTION
Qt 5.6 no longer includes QtWebKit in its binaries. This module has been replaced with QtWebEngine. The OpenSesame webbrowser module now uses QtWebEngine if it cannot find QtWebKit.

Another fix involves adding a check for __name__ == "__main__" in the main opensesame module, which is a strict requirement for multiprocessing under Windows or other platforms that lack os.fork() functionality (see https://docs.python.org/2/library/multiprocessing.html#windows).

Finally, there is a small fix in the font checking, that otherwise caused a crash on OSX.