### PR TITLE
Fix crash on Open Experiment

### DIFF
--- a/libqtopensesame/misc/process.py
+++ b/libqtopensesame/misc/process.py
@@ -21,7 +21,7 @@ from libopensesame.py3compat import *
 import platform, sys
 
 if platform.system() == 'Darwin' and \
-	sys.version_info[0] < 3:
+	sys.version_info < (3,4):
 		# In OS X Python < 3.4 the multiprocessing module is horribly broken,  
 		# but a fixed version has been released as the 'billiard' module
 		import billiard as multiprocessing

--- a/libqtopensesame/qtopensesame.py
+++ b/libqtopensesame/qtopensesame.py
@@ -668,6 +668,11 @@ class qtopensesame(QtWidgets.QMainWindow, base_component):
 			path = QtWidgets.QFileDialog.getOpenFileName(self.ui.centralwidget,
 				_(u"Open file"), filter=self.open_file_filter,
 				directory=cfg.file_dialog_path)
+		# In PyQt5, the QFileDialog.getOpenFileName returns a tuple instead of 
+		# a string, of which the first position contains the path. check for that 
+		# here.
+		if isinstance(path,tuple):
+			path = path[0]
 		if path is None or path == u'' or ( \
 			not path.lower().endswith(u'.opensesame') and \
 			not  path.lower().endswith(u'.opensesame.tar.gz') and \

--- a/libqtopensesame/qtopensesame.py
+++ b/libqtopensesame/qtopensesame.py
@@ -795,6 +795,10 @@ class qtopensesame(QtWidgets.QMainWindow, base_component):
 		path = QtWidgets.QFileDialog.getSaveFileName(self.ui.centralwidget,
 			_(u'Save as…'), directory=cfg.file_dialog_path,
 			filter=self.save_file_filter)
+		# In PyQt5, the QFileDialog.getOpenFileName returns a tuple instead of 
+		# a string, of which the first position contains the path.
+		if isinstance(path,tuple):
+			path = path[0]
 		if path is None or path == u"":
 			return
 		if not path.lower().endswith(u'.osexp'):

--- a/libqtopensesame/qtopensesamerun.py
+++ b/libqtopensesame/qtopensesamerun.py
@@ -66,6 +66,10 @@ class qtopensesamerun(QtWidgets.QMainWindow, base_component):
 			u"OpenSesame files (*.osexp *.opensesame.tar.gz *.opensesame);;OpenSesame script and file pool (*.opensesame.tar.gz);;OpenSesame script (*.opensesame)"
 		path = QtWidgets.QFileDialog.getOpenFileName(self, \
 			u"Open experiment file", filter = file_type_filter)
+		# In PyQt5, the QFileDialog.getOpenFileName returns a tuple instead of 
+		# a string, of which the first position contains the path.
+		if isinstance(path,tuple):
+			path = path[0]
 		if path == u"":
 			return
 		self.ui.edit_experiment.setText(path)
@@ -76,6 +80,11 @@ class qtopensesamerun(QtWidgets.QMainWindow, base_component):
 
 		path = QtWidgets.QFileDialog.getSaveFileName(self, \
 			u"Choose a location for the logfile")
+		# In PyQt5, the QFileDialog.getOpenFileName returns a tuple instead of 
+		# a string, of which the first position contains the path.
+		if isinstance(path,tuple):
+			path = path[0]
+			
 		if path == u"":
 			return
 		self.ui.edit_logfile.setText(path)

--- a/libqtopensesame/runners/base_runner.py
+++ b/libqtopensesame/runners/base_runner.py
@@ -111,10 +111,14 @@ class base_runner(object):
 				u'subject-%d.csv' % subject_nr)
 			# Get the data file
 			csv_filter = u'Comma-separated values (*.csv)'
-			logfile = str(QtWidgets.QFileDialog.getSaveFileName( \
+			logfile = QtWidgets.QFileDialog.getSaveFileName( \
 				self.main_window.ui.centralwidget, \
 				_(u"Choose location for logfile (press 'escape' for default location)"), \
-				suggested_path, filter=csv_filter))
+				suggested_path, filter=csv_filter)
+			# In PyQt5, the QFileDialog.getOpenFileName returns a tuple instead of 
+			# a string, of which the first position contains the path.
+			if isinstance(logfile,tuple):
+				logfile = logfile[0]
 			# An empty string indicates that the dialogue was cancelled, in
 			# which case we fall back to a default location.
 			if logfile == u'':

--- a/opensesame
+++ b/opensesame
@@ -18,9 +18,8 @@ You should have received a copy of the GNU General Public License
 along with OpenSesame.  If not, see <http://www.gnu.org/licenses/>.
 """
 
-from libqtopensesame import __main__
-
 # checking if __name__ is __main__ is required to let multiprocessing correctly
 # work on Windows (or any other platform that is not able to use os.fork)
 if __name__ == "__main__":
+	from libqtopensesame import __main__
 	__main__.opensesame()


### PR DESCRIPTION
When pressing Cancel on the Open File dialog, or opening of some experiments (it doesn't always occur... weird) OpenSesame crashed. This is because it expected the path variable to be a string, while in Qt5 the QFileDialog.getOpenFileName returns a tuple instead of a string. The first position of this tuple contains the expected value for path.