### PR TITLE
Fixed qt4-qt5 inconsistency when processing result of fileDialog

### DIFF
--- a/libqtopensesame/widgets/pool_widget.py
+++ b/libqtopensesame/widgets/pool_widget.py
@@ -137,6 +137,11 @@ class pool_widget(base_widget):
 			directory=cfg.default_pool_folder)
 		if not path_list:
 			return
+
+		# Qt5 puts the first element in another list, check for that here
+		if isinstance(path_list[0], list):
+			path_list = path_list[0]
+
 		cfg.default_pool_folder = os.path.dirname(path_list[0])
 		self.add(path_list)
 


### PR DESCRIPTION
In Qt4 the result of the file selection dialog was a list of selected files. In Qt5, it is a tuple, with this list positioned at the first place.