### PR TITLE
Fixed suppression of same notification within certain interval

### DIFF
--- a/opensesame_extensions/notifications/notifications.py
+++ b/opensesame_extensions/notifications/notifications.py
@@ -58,10 +58,12 @@ class notifications(base_extension):
 		# See if notification has been shown before. If it is within
 		# self.expiration_time, don't show it again.
 		if not always_show:
-			if (message, category, timeout) in self.old_notifications:
-				prev_time = self.old_notifications[(message, category, timeout)]
+			if (message, category, timeout, buttontext) in self.old_notifications:
+				prev_time = self.old_notifications[(message, category, timeout, 
+					buttontext)]
 				if current_time - prev_time < self.expiration_time:
 					return
 			# Add notification to old notifications list.
-			self.old_notifications[(message, category, timeout, buttontext)] = current_time
+			self.old_notifications[(message, category, timeout, 
+				buttontext)] = current_time
 		self.notification_area.display(message, category, timeout, buttontext)


### PR DESCRIPTION
The new var *buttontext* was not checked for when determining if a notification should be shown again, causing even duplicate notifications to be regarded as new.