### PR TITLE
Updated URL

### DIFF
--- a/opensesame_extensions/opensesame_3_notifications/old-experiment.md
+++ b/opensesame_extensions/opensesame_3_notifications/old-experiment.md
@@ -7,7 +7,7 @@ Don't worry! This shouldn't cause any problems. But, just to be safe, I recommen
 What do you want to do?
 
 [Save experiment now](opensesame://action.save){: .important-button} <br />
-[See what's new in OpenSesame 3](new:html://osdoc.cogsci.nl/3.0/miscellaneous/important-changes-3/){: .button} <br />
+[See what's new in OpenSesame 3](new:html://osdoc.cogsci.nl/3.1/important-changes-3/){: .button} <br />
 
 Or you can:
 


### PR DESCRIPTION
When running 3.1.2 for the first time I spotted another outdated URL. I'm only not sure what is better:
- /osdoc.cogsci.nl/3.1/important-changes-3/
- /osdoc.cogsci.nl/important-changes-3/

As the last one seems to be redirected to 3.1 and would therefore be future proof for 3.2 etc right?

Best,
Jarik
aka URLhunter