### PR TITLE
Corrected some mistakes (try 2)

### DIFF
--- a/libopensesame/response_store.py
+++ b/libopensesame/response_store.py
@@ -124,7 +124,7 @@ class response_store(object):
 		name: acc
 
 		desc:
-			The percentage correct responses for all responses that are included
+			The percentage of correct responses for all responses that are included
 			in feedback. If there are no responses to give feedback on,
 			'undefined' is returned.
 		"""
@@ -138,7 +138,7 @@ class response_store(object):
 	def avg_rt(self):
 
 		"""
-		name: acc
+		name: avg_rt
 
 		desc:
 			The average response time for all responses that are included
@@ -181,7 +181,7 @@ class response_store(object):
 	def response_time(self):
 
 		"""
-		name: correct
+		name: response_time
 
 		desc:
 			A list of all response times (float or None).
@@ -206,7 +206,7 @@ class response_store(object):
 	def feedback(self):
 
 		"""
-		name: item
+		name: feedback
 
 		desc:
 			A list of the feedback status (True or False) associated with each


### PR DESCRIPTION
Corrected some mistakes, I tried earlier in https://github.com/smathot/osdoc/pull/69 (I should have looked better into response_store.py).

The only thing I don't know how to fix is that responses.acc description is not fully displayed. See screenshot below:
![error](https://cloud.githubusercontent.com/assets/8225621/18638082/1463a42a-7e8f-11e6-84ff-147a888bfe17.PNG)
