### PR TITLE
Raise error for invalid 'bgmode' arguments

### DIFF
--- a/openexp/_canvas/canvas.py
+++ b/openexp/_canvas/canvas.py
@@ -1197,9 +1197,9 @@ def _gabor(orient, freq, env=u"gaussian", size=96, stdev=12, phase=0,
 			elif bgmode == u"col2":
 				amp = amp * f
 			else:
-				raise osexception((u"Invalid argument for bgmode: %s " % bgmode) + 
-									u"(should be one of 'avg','col2')")
-
+				raise osexception(u"Invalid argument for bgmode: %s "
+								  u"(should be one of 'avg','col2')" % bgmode)
+			
 			r = col1.r * amp + col2.r * (1.0 - amp)
 			g = col1.g * amp + col2.g * (1.0 - amp)
 			b = col1.b * amp + col2.b * (1.0 - amp)
@@ -1264,8 +1264,8 @@ def _noise_patch(env=u"gaussian", size=96, stdev=12, col1=u"white",
 			elif bgmode == u"col2":
 				amp = amp * f
 			else:
-				raise osexception((u"Invalid argument for bgmode: %s " % bgmode) + 
-									u"(should be one of 'avg','col2')")
+				raise osexception(u"Invalid argument for bgmode: %s "
+								  u"(should be one of 'avg','col2')" % bgmode)
 
 			r = col1.r * amp + col2.r * (1.0 - amp)
 			g = col1.g * amp + col2.g * (1.0 - amp)

--- a/openexp/_canvas/canvas.py
+++ b/openexp/_canvas/canvas.py
@@ -1194,8 +1194,12 @@ def _gabor(orient, freq, env=u"gaussian", size=96, stdev=12, phase=0,
 			# Apply the envelope
 			if bgmode == u"avg":
 				amp = amp * f + 0.5 * (1.0 - f)
-			else:
+			elif bgmode == u"col2":
 				amp = amp * f
+			else:
+				raise osexception((u"Invalid argument for bgmode: %s " % bgmode) + 
+									u"(should be one of 'avg','col2')")
+
 			r = col1.r * amp + col2.r * (1.0 - amp)
 			g = col1.g * amp + col2.g * (1.0 - amp)
 			b = col1.b * amp + col2.b * (1.0 - amp)
@@ -1257,8 +1261,12 @@ def _noise_patch(env=u"gaussian", size=96, stdev=12, col1=u"white",
 			# Apply the envelope
 			if bgmode == u"avg":
 				amp = amp * f + 0.5 * (1.0 - f)
-			else:
+			elif bgmode == u"col2":
 				amp = amp * f
+			else:
+				raise osexception((u"Invalid argument for bgmode: %s " % bgmode) + 
+									u"(should be one of 'avg','col2')")
+
 			r = col1.r * amp + col2.r * (1.0 - amp)
 			g = col1.g * amp + col2.g * (1.0 - amp)
 			b = col1.b * amp + col2.b * (1.0 - amp)


### PR DESCRIPTION
Rather than using 'col2' for anything that is not 'avg', the argument has to be avg or col2.

This shields against potential incorrect outcomes, for example if the user forgets the correct terminology. They could, say, call these functions with `..., bgmode="average" `and get the behavior as if ` "col2" ` was used without any warning or error message. 

I feel an  error for incorrect keywords is the safest and most appropriate behavior.
Thanks!
W