### PR TITLE
Improved system and architecture info

### DIFF
--- a/opensesame_extensions/system_information/system_information.py
+++ b/opensesame_extensions/system_information/system_information.py
@@ -84,11 +84,13 @@ class system_information(base_extension):
 		
 		# platform.architecture() does not seem to work correctly on Windows so a solution found on stackoverflow is used
 		# http://stackoverflow.com/questions/2208828/detect-64bit-os-windows-in-python
-		if(platform.machine().endswith('64')):
+		if(platform.platform().startswith('Windows') and platform.machine().endswith('64')):
 			t = 'win64'
-		else:
+		elif(platform.platform().startswith('Windows') and not platform.machine().endswith('64')):
 			t = 'win32'
-		
+		else:
+			t = platform.architecture()[0]
+			
 		md = safe_read(self.ext_resource(u'system-information.md')) % {
 			u'system' : platform.platform(),
 			u'architecture' : t,

--- a/opensesame_extensions/system_information/system_information.py
+++ b/opensesame_extensions/system_information/system_information.py
@@ -81,9 +81,17 @@ class system_information(base_extension):
 				l.append(u'%s %s' % (name, getattr(mod, a)))
 				continue
 			l.append(u'%s [version unknown]' % name)
+		
+		# platform.architecture() does not seem to work correctly on Windows so a solution found on stackoverflow is used
+		# http://stackoverflow.com/questions/2208828/detect-64bit-os-windows-in-python
+		if(platform.machine().endswith('64')):
+			t = 'win64'
+		else:
+			t = 'win32'
+		
 		md = safe_read(self.ext_resource(u'system-information.md')) % {
-			u'system' : platform.system(),
-			u'architecture' : platform.architecture()[0],
+			u'system' : platform.platform(),
+			u'architecture' : t,
 			u'modules' : u'- ' + u'\n- '.join(l)
 			}
 		self.tabwidget.open_markdown(md, icon=self.icon(),


### PR DESCRIPTION
Tested by replacing the *system_information.py* file in the installed version of OS3.1.4 on:
(so without https://github.com/smathot/OpenSesame/commit/2d0d94216dc021af960833d32c3ea17b56cdd951)
* Win7 x64
was:
System: Windows
Architecture: 32bit
becomes:
System: Windows-**7-6.1.7601-SP1**
Architecture: **64bit**

* Win7 x32
was:
System: Windows
Architecture: 32bit
becomes:
System: Windows-**7-6.1.7600-SP0**
Architecture: 32bit

* Ubuntu16.04 x64
was:
System: Linux
Architecture: 64bit
becomes:
System: Linux-**4.4.0-21-generic-x86_64-with-Ubuntu-16.04-xenial**
Architecture: 64bit

* Win10 x64
was:
System: Windows
Architecture: 32bit
becomes:
System: Windows-**10-10.0.14393**
Architecture: **64bit**

* macOS Sierra
was:
System: Darwin
Architecture: 64bit
becomes:
System: Darwin-**16.1.0-x86_64-i386-64bit**
Architecture: 64bit

Note "Darwin translations" can be found here:
https://en.wikipedia.org/wiki/Darwin_%28operating_system%29#Release_history