### PR TITLE
Fixed segfault on mac when run with python 3

### DIFF
--- a/libqtopensesame/__main__.py
+++ b/libqtopensesame/__main__.py
@@ -32,7 +32,7 @@ def opensesame():
 	# In OS X the multiprocessing module is horribly broken, but a fixed
 	# version has been released as the 'billiard' module
 	if platform.system() == 'Darwin':
-		# Use normal multirpocessing module from python 3.4 and on
+		# Use normal multiprocessing module from python 3.4 and on
 		if sys.version_info >= (3,4):
 			from multiprocessing import freeze_support, set_start_method
 			freeze_support()

--- a/libqtopensesame/__main__.py
+++ b/libqtopensesame/__main__.py
@@ -36,7 +36,7 @@ def opensesame():
 		if sys.version_info >= (3,4):
 			from multiprocessing import freeze_support, set_start_method
 			freeze_support()
-			set_start_method('forkserver')
+			set_start_method('spawn')
 		else:
 			from billiard import freeze_support, forking_enable
 			freeze_support()


### PR DESCRIPTION
Pygame doesn't play nice with multiprocessing's 'forkserver' method of creating new processes, so I changed it to 'spawn'. This mimics windows way of creating new processes and doesn't cause a crash. 

More and more reasons keep piling up to steadily move away from pygame ;)