### PR TITLE
Add set_pos (mouse) to PsychoPy backend

### DIFF
--- a/openexp/_mouse/psycho.py
+++ b/openexp/_mouse/psycho.py
@@ -76,6 +76,10 @@ class psycho(mouse.mouse, psycho_coordinates):
 
 		return self.from_xy(self.mouse.getPos()), self.experiment.time()
 
+	def set_pos(self, pos=(0,0)):
+
+		self.mouse.setPos(self.to_xy(pos))
+		
 	def get_pressed(self):
 
 		return tuple(self.mouse.getPressed(getTime=False))


### PR DESCRIPTION
The set_pos function was missing from the mouse part of PsychoPy backend