### PR TITLE
Fix TypeError with QIcon

### DIFF
--- a/libqtopensesame/misc/theme.py
+++ b/libqtopensesame/misc/theme.py
@@ -120,7 +120,7 @@ class theme:
 		else:
 			fallback = category + u'-x-generic'
 		return QtGui.QIcon.fromTheme(filetype,
-			fallback=QtGui.QIcon.fromTheme(fallback))
+			QtGui.QIcon.fromTheme(fallback))
 
 	def qicon(self, icon):
 


### PR DESCRIPTION
After an upgrade to PyQt 5.8.1, I suddenly faced this error:

~~~
Extension error

item-stack: 
exception message: fromTheme() takes no keyword arguments
time: Wed Mar 15 15:42:29 2017
exception type: TypeError

Traceback:
  File "/Users/daniel/Github/OpenSesame/libqtopensesame/extensions/_extension_manager.py", line 133, in fire
    ext.fire(event, **kwdict)
  File "/Users/daniel/Github/OpenSesame/libqtopensesame/extensions/_base_extension.py", line 386, in fire
    getattr(self, u'event_%s' % event)(**kwdict)
  File "/Users/daniel/Github/OpenSesame/opensesame_extensions/get_started/get_started.py", line 86, in event_open_recent_0
    self.main_window.open_file(path=self.main_window.recent_files[0])
  File "/Users/daniel/Github/OpenSesame/libqtopensesame/qtopensesame.py", line 760, in open_file
    self.ui.pool_widget.refresh()
  File "/Users/daniel/Github/OpenSesame/libqtopensesame/widgets/pool_widget.py", line 184, in refresh
    icon = self.theme.qfileicon(self.pool[path])
  File "/Users/daniel/Github/OpenSesame/libqtopensesame/misc/theme.py", line 123, in qfileicon
    fallback=QtGui.QIcon.fromTheme(fallback))
TypeError: fromTheme() takes no keyword arguments
~~~

Apparently, it is no longer allowed to provide the fallback icon as a keyword argument. Removing the keyword indeed fixed the problem.