### PR TITLE
Enhance color specifications #533

### DIFF
--- a/openexp/_color/color.py
+++ b/openexp/_color/color.py
@@ -80,7 +80,7 @@ class color(object):
 		"""
 		is_rgb = lambda c: hasattr(c, '__len__') \
 			and len(c) == 3 \
-			and all(isinstance(i, numbers.Number) and 0 <= i <= 255 for i in c)
+			and all(isinstance(i, numbers.Integral) and 0 <= i <= 255 for i in c)
 
 		if isinstance(colorspec, int):
 			return webcolors.rgb_to_hex((colorspec, colorspec, colorspec))

--- a/openexp/_color/color.py
+++ b/openexp/_color/color.py
@@ -19,6 +19,7 @@ along with OpenSesame.  If not, see <http://www.gnu.org/licenses/>.
 
 from libopensesame.py3compat import *
 import webcolors
+import numbers
 from libopensesame.exceptions import osexception
 
 class color(object):
@@ -71,23 +72,19 @@ class color(object):
 		arguments:
 			colorspec:
 				desc:	A color specification.
-				type:	[str, unicode, tuple, int]
+				type:	[str, unicode, array-like, int]
 
 		returns:
 			desc:	A hexadecimal color specification.
 			type:	unicode
 		"""
+		is_rgb = lambda c: hasattr(c, '__len__') \
+			and len(c) == 3 \
+			and all(isinstance(i, numbers.Number) and 0 <= i <= 255 for i in c)
 
 		if isinstance(colorspec, int):
 			return webcolors.rgb_to_hex((colorspec, colorspec, colorspec))
-		if isinstance(colorspec, tuple):
-			if len(colorspec) != 3:
-				raise osexception(
-					u'Invalid color specification: %s' % str(colorspec))
-			for v in colorspec:
-				if not isinstance(v, int):
-					raise osexception(
-						u'Invalid color specification: %s' % str(colorspec))
+		if is_rgb(colorspec):
 			return webcolors.rgb_to_hex(colorspec)
 		if isinstance(colorspec, basestring):
 			try:


### PR DESCRIPTION
When changing the documentation string, I could find a better descriptor than "array-like" to include all data structures that have a length. 
