### PR TITLE
Set audiosystem_autostart to False for Expyriment

### DIFF
--- a/openexp/_canvas/xpyriment.py
+++ b/openexp/_canvas/xpyriment.py
@@ -265,6 +265,7 @@ class xpyriment(canvas.canvas, xpyriment_coordinates):
 		control.defaults.audiosystem_channels = experiment.var.sound_channels
 		control.defaults.audiosystem_buffer_size = \
 			experiment.var.sound_buf_size
+		control.defaults.audiosystem_autostart = False
 
 		# Initialize. If Expyriment jumps into interactive mode, it reads from
 		# the stdin, and crashes. Thus we explicitly disable the interactive-


### PR DESCRIPTION
Set audiosystem_autostart to *False*. This skips the `mixer.init()' in [_experiment_control.py
](https://github.com/smathot/expyriment/blob/master/expyriment/control/_experiment_control.py#L303) as it is initialized by openexp.sampler._legacy.init_sound(). This further fixes #541